### PR TITLE
fix: "Unable to resolve specifier 'react/jsx-dev-runtime' imported from"

### DIFF
--- a/remote/src/bootstrap.tsx
+++ b/remote/src/bootstrap.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/remote/src/main.tsx
+++ b/remote/src/main.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import { initFederation } from '@softarc/native-federation';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-	<React.StrictMode>
-		<App />
-	</React.StrictMode>
-);
+(async () => {
+  await initFederation();
+
+  await import('./bootstrap');
+})();
+


### PR DESCRIPTION
when 'remote' project `npm run dev` independently, show error  "Unable to resolve specifier 'react/jsx-dev-runtime' imported from..."