### PR TITLE
fix: move lazy outside the render body

### DIFF
--- a/host/src/App.tsx
+++ b/host/src/App.tsx
@@ -3,12 +3,12 @@ import { of, tap } from 'rxjs';
 import './App.css';
 import Counter from './components/Counter';
 
-export default () => {
-	const Remote = lazy(
-		// @ts-ignore
-		async () => import('remote/remote-app'),
-	);
+const Remote = lazy(
+	// @ts-ignore
+	async () => import('remote/remote-app'),
+);
 
+export default () => {
 	useEffect(() => {
 		of('emit')
 			.pipe(tap(() => console.log("I'm RxJs from host")))


### PR DESCRIPTION
By calling `lazy` inside the component body it tries to load It on every render causing remounting and suspense to trigger loading state again.

In this demo is not a problem cause the host doesn't rerender but It might be a cause of confusion

## Before

https://github.com/user-attachments/assets/8f119bda-a9c0-4bf7-8645-b93e96c1ba2a

## After

https://github.com/user-attachments/assets/8286f18c-a900-4ef4-9f5b-fe72370e9553

